### PR TITLE
fix: resolve repository dependency in test code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 docker/
 .vscode/
 dist/
-
+coverage/

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,14 +1,37 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { UserController } from './user.controller'
 import { UserService } from './user.service'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { User } from './user.entity'
+import { RawPassword } from 'src/type'
 
 describe('UserController', () => {
   let app: TestingModule
 
   beforeAll(async () => {
+    const now = Date.now()
     app = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService],
+      providers: [
+        UserService,
+        {
+          // ToDo: Make it more nicer, wrap with gentle utility
+          provide: getRepositoryToken(User),
+          useValue: {
+            _mock: {
+              id: 1,
+              email: 'initial-user@test.com',
+              password: 'password' as RawPassword,
+              name: 'initial-user',
+              createdAt: now,
+              updatedAt: now,
+            },
+            find() {
+              return this._mock
+            },
+          }
+        },
+      ],
     }).compile()
   })
 

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -17,11 +17,11 @@ export class User {
   @Column('varchar', { length: 255 })
   password: Password
 
-  @CreateDateColumn({ type: 'bigint', name: 'created_at' })
-  readonly createdAt?: number
+  @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
+  readonly createdAt?: Date
 
-  @UpdateDateColumn({ type: 'bigint', name: 'updated_at' })
-  readonly updatedAt?: number
+  @UpdateDateColumn({ type: 'timestamp', name: 'updated_at' })
+  readonly updatedAt?: Date
 
   constructor(partial: Partial<User>) {
     Object.assign(this, partial)

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,12 +1,36 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { UserService } from './user.service'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { User } from './user.entity'
+import { RawPassword } from 'src/type'
 
 describe('UserService', () => {
   let service: UserService
 
   beforeEach(async () => {
+    const now = Date.now()
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        {
+          // ToDo: Make it more nicer, wrap with gentle utility
+          provide: getRepositoryToken(User),
+          useValue: {
+            _mock: {
+              id: 1,
+              email: 'initial-user@test.com',
+              password: 'password' as RawPassword,
+              name: 'initial-user',
+              createdAt: now,
+              updatedAt: now,
+            },
+            find() {
+              return this._mock
+            },
+          }
+        },
+
+      ],
     }).compile()
 
     service = module.get<UserService>(UserService)


### PR DESCRIPTION
About
-----

closes #4

Because injection process done by typeorm wasn't included in test, we need to inject repository mock for testing by hand. for now, I put roughly made mock, but should be refactored to use nicer classes and things.

Thanks to the following issue and comment!
https://github.com/nestjs/nest/issues/363#issuecomment-359115921
one note is that I needed to put mock into `providers` instead of `imports` which were suggested in the issue. maybe a nestjs version change.

Changes
-----

- Inject mock repository for injection
- small fix on user entity; type in database and class

Further ToDo
-----

- Make more generic mock class to ease injections