### PR TITLE
fix: resolve "Jest didn't exit after it has completed" when e2e-test is running 

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -20,4 +20,8 @@ describe('AppController (e2e)', () => {
       .get('/')
       .expect(200)
       .expect('Hello World!'))
+
+  afterAll(async () => {
+    await app.close()
+  })
 })


### PR DESCRIPTION
- Added function:app.close() at afterAll.